### PR TITLE
Projects are grid display

### DIFF
--- a/components/index.module.css
+++ b/components/index.module.css
@@ -48,13 +48,12 @@
 /*Content for projects*/
 
 .projects {
-    display: flex;
-    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 330px);
     flex-wrap:wrap;
-    justify-content: space-around;
     column-gap: 20px;
+    justify-content:center;
 }
-
 
 .project {
     width: 330px;

--- a/components/index.module.css
+++ b/components/index.module.css
@@ -51,7 +51,7 @@
     display: flex;
     width: 100%;
     flex-wrap:wrap;
-    justify-content: space-evenly;
+    justify-content: space-around;
     column-gap: 20px;
 }
 


### PR DESCRIPTION
I had to make this change because Safari is not yet compatible with gaps in flex boxes, unfortunately. Maybe later in the future I will make these into flex boxes again (they're so cool!)